### PR TITLE
Add strict Content Type check option

### DIFF
--- a/scr/chrome/content/lookout.js
+++ b/scr/chrome/content/lookout.js
@@ -609,30 +609,36 @@ var lookout_lib = {
 		for( index in currentAttachments ) {
 			var attachment = currentAttachments[index];
 			lookout.log_msg( attachment.toSource(), 8 );
-			// we only decode tnef files
-//      if( (/^application\/ms-tnef/i).test( attachment.contentType ) ) {
-{
+			var scanfile = true;
+
+			// Use strict content type matching to improve performance as a togglable option
+      if( lookout.get_bool_pref( "strict_contenttype" ) ){
+				var scanfile = (/^application\/ms-tnef/i).test( attachment.contentType )
+				lookout.log_msg( "LookOut:    Content Type: '" + attachment.contentType + "'", 7 );
+			}
+			if(scanfile){
+
 				lookout.log_msg( "LookOut:    found tnef", 7 );
 
-	// open the attachment and look inside
-	var stream_listener = new LookoutStreamListener();
-	stream_listener.attachment = attachment;
-	stream_listener.mAttUrl = attachment.url;
-	if( attachment.uri )
-		stream_listener.mMsgUri = attachment.uri;
-	else
-		stream_listener.mMsgUri = attachment.messageUri;
-	stream_listener.mMsgHdr = lookout_lib.msg_hdr_for_current_msg( stream_listener.mMsgUri );
-	if( ! stream_listener.mMsgHdr )
-		lookout.log_msg( "LookOut:    no message header for this service", 5 );
-	stream_listener.action_type = LOOKOUT_ACTION_SCAN;
+				// open the attachment and look inside
+				var stream_listener = new LookoutStreamListener();
+				stream_listener.attachment = attachment;
+				stream_listener.mAttUrl = attachment.url;
+				if( attachment.uri )
+					stream_listener.mMsgUri = attachment.uri;
+				else
+					stream_listener.mMsgUri = attachment.messageUri;
+				stream_listener.mMsgHdr = lookout_lib.msg_hdr_for_current_msg( stream_listener.mMsgUri );
+				if( ! stream_listener.mMsgHdr )
+					lookout.log_msg( "LookOut:    no message header for this service", 5 );
+				stream_listener.action_type = LOOKOUT_ACTION_SCAN;
 
-	var mms = messenger2.messageServiceFromURI( stream_listener.mMsgUri )
-									 .QueryInterface( Components.interfaces.nsIMsgMessageService );
-	var attname = attachment.name ? attachment.name : attachment.displayName;
-	mms.openAttachment( attachment.contentType, attname,
-					attachment.url, stream_listener.mMsgUri, stream_listener,
-					null, null );
+				var mms = messenger2.messageServiceFromURI( stream_listener.mMsgUri )
+												 .QueryInterface( Components.interfaces.nsIMsgMessageService );
+				var attname = attachment.name ? attachment.name : attachment.displayName;
+				mms.openAttachment( attachment.contentType, attname,
+								attachment.url, stream_listener.mMsgUri, stream_listener,
+								null, null );
 			}
 		}
 	},

--- a/scr/chrome/content/options.xul
+++ b/scr/chrome/content/options.xul
@@ -44,9 +44,11 @@
       <preference id="attach_raw_mapi_pref" name="extensions.lookout.attach_raw_mapi" type="bool"/>
       <preference id="direct_to_calendar_pref" name="extensions.lookout.direct_to_calendar" type="bool"/>
       <preference id="disable_filename_character_set_pref" name="extensions.lookout.disable_filename_character_set" type="bool"/>
+      <preference id="strict_contenttype_set_pref" name="extensions.lookout.strict_contenttype" type="bool"/>
     </preferences>
     <checkbox id="attach_raw_mapi_check" preference="attach_raw_mapi_pref" label="&attach_raw_mapi_check.label;" accesskey="&attach_raw_mapi_check.accesskey;"/>
     <checkbox id="direct_to_calendar_check" preference="direct_to_calendar_pref" label="&direct_to_calendar_check.label;" accesskey="&direct_to_calendar_check.accesskey;"/>
     <checkbox id="disable_filename_character_set_check" preference="disable_filename_character_set_pref" label="&disable_filename_character_set_check.label;" accesskey="&disable_filename_character_set_check.accesskey;"/>
+    <checkbox id="strict_contenttype_set_check" preference="strict_contenttype_set_pref" label="&strict_contenttype_set_check.label;" accesskey="&strict_contenttype_set_check.accesskey;"/>
   </prefpane>
 </prefwindow>

--- a/scr/chrome/locale/en-US/prefwindow.dtd
+++ b/scr/chrome/locale/en-US/prefwindow.dtd
@@ -6,4 +6,6 @@
 <!ENTITY direct_to_calendar_check.accesskey "C">
 <!ENTITY disable_filename_character_set_check.label "Disable Filename Character Set Conversion">
 <!ENTITY disable_filename_character_set_check.accesskey "F">
+<!ENTITY strict_contenttype_set_check.label "Strict Content Type Matching">
+<!ENTITY strict_contenttype_set_check.accesskey "S">
 

--- a/scr/defaults/preferences/lookout.js
+++ b/scr/defaults/preferences/lookout.js
@@ -1,6 +1,7 @@
 pref( "extensions.lookout.attach_raw_mapi", false );
 pref( "extensions.lookout.direct_to_calendar", false );
 pref( "extensions.lookout.disable_filename_character_set", false );
+pref( "extensions.lookout.strict_contenttype", true );
 pref( "extensions.lookout.body_part_prefix", "body_part_" );
 // See http://kb.mozillazine.org/Localize_extension_descriptions
 pref("extensions.lookout@aron.rubin.description", "chrome://lookout/locale/lookout.properties");


### PR DESCRIPTION
Performance was affected by attempting to scan attachments in order to catch all variations.

Adding a preference option to enable/disable this behaviour appears to be the best solution